### PR TITLE
允许发送空文本消息

### DIFF
--- a/app/src/main/java/com/yhchat/canary/data/repository/MessageRepository.kt
+++ b/app/src/main/java/com/yhchat/canary/data/repository/MessageRepository.kt
@@ -347,7 +347,8 @@ class MessageRepository @Inject constructor(
                 block()
             }
 
-            payload.text?.takeIf { it.isNotBlank() }?.let { markContent { contentBuilder.text = it } }
+            val isSendTextAllowEmptySetting = true//TODO 不知道这里怎么读取设置
+            payload.text?.takeIf { it.isNotBlank() || isSendTextAllowEmptySetting }?.let { markContent { contentBuilder.text = it } }
 
             val resolvedButtons = when {
                 payload.contentType == CONTENT_TYPE_A2UI && payload.buttons.isNullOrBlank() -> payload.text

--- a/app/src/main/java/com/yhchat/canary/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/yhchat/canary/ui/chat/ChatScreen.kt
@@ -339,7 +339,10 @@ fun ChatScreen(
     val showTtsButton by rememberBooleanPreference("layout_settings", "chat_show_tts_button", true)
     val showRefreshButton by rememberBooleanPreference("layout_settings", "chat_show_refresh_button", true)
     val hideTopAppBar by rememberBooleanPreference("layout_settings", "chat_hide_top_app_bar", false)
-    
+
+    // 读取内容设置：是否允许发送空文本消息
+    val isSendTextAllowEmptySetting = context.getSharedPreferences("send_text_settings", Context.MODE_PRIVATE) .getBoolean("send_text_allow_empty", false)//英语不好不知道起什么变量名
+
     // 初始化聊天
     LaunchedEffect(chatId, chatType) {
         viewModel.initChat(chatId, chatType, userId)
@@ -967,7 +970,8 @@ fun ChatScreen(
                                         msg.content.text?.let { text ->
                                             viewModel.sendMessage(
                                                 text = text,
-                                                contentType = msg.contentType
+                                                contentType = msg.contentType,
+                                                isSendTextAllowEmptySetting = isSendTextAllowEmptySetting, // +1有必要允许发送空文本消息吗，嗯也许用来+1发送别人发的引用消息吧。嗯似乎引用消息的+1还没做好
                                             )
                                             Toast.makeText(context, "+1 文本消息已发送", Toast.LENGTH_SHORT).show()
                                         } ?: Toast.makeText(context, "消息内容为空", Toast.LENGTH_SHORT).show()
@@ -1333,7 +1337,7 @@ fun ChatScreen(
                 text = inputText,
                 onTextChange = { inputText = it },
                 onSendMessage = {
-                    if (inputText.isNotEmpty()) {
+                    if (inputText.isNotEmpty()||isSendTextAllowEmptySetting) {
                         val messageText = inputText
                         
                         // 解析@用户，提取用户ID列表
@@ -1396,7 +1400,8 @@ fun ChatScreen(
                                 android.util.Log.e("ChatScreen", "发送消息失败: $error")
                                 // 可以选择显示Toast提示
                                 // android.widget.Toast.makeText(context, "发送失败: $error", android.widget.Toast.LENGTH_SHORT).show()
-                            }
+                            },
+                            isSendTextAllowEmptySetting = isSendTextAllowEmptySetting
                         )
                     }
                 },
@@ -1507,7 +1512,8 @@ fun ChatScreen(
                                 quoteImageName = quotedImageName,
                                 quoteVideoUrl = quotedVideoUrl,
                                 quoteVideoTime = quotedVideoTime,
-                                commandId = instruction.id
+                                commandId = instruction.id,
+                                isSendTextAllowEmptySetting = isSendTextAllowEmptySetting,// 这里有必要允许发送空文本消息吗，Bot的直发指令应该不能是空文本吧
                             )
                             inputText = ""
                             selectedInstruction = null

--- a/app/src/main/java/com/yhchat/canary/ui/chat/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/yhchat/canary/ui/chat/viewmodel/ChatViewModel.kt
@@ -1684,15 +1684,16 @@ class ChatViewModel @Inject constructor(
         commandId: Long? = null,
         mentionedIds: List<String>? = null,
         onSuccess: () -> Unit = {},
-        onError: (String) -> Unit = {}
+        onError: (String) -> Unit = {},
+        isSendTextAllowEmptySetting: Boolean = false,//TODO 英语不好不知道起什么变量名
     ) {
-        // 如果是指令消息，允许空文本；否则检查文本是否为空
         if (currentChatId.isEmpty()) {
             Log.w(tag, "Chat not initialized")
             onError("Chat not initialized")
             return
         }
-        if (text.isEmpty() && commandId == null) {
+        // 如果是指令消息，允许空文本；否则检查文本是否为空；如果设置了允许发送空文本消息的话也行
+        if (text.isEmpty() && commandId == null && !isSendTextAllowEmptySetting) {
             Log.w(tag, "Cannot send empty message without command")
             onError("Cannot send empty message")
             return

--- a/app/src/main/java/com/yhchat/canary/ui/components/ChatInputBar.kt
+++ b/app/src/main/java/com/yhchat/canary/ui/components/ChatInputBar.kt
@@ -116,6 +116,11 @@ fun ChatInputBar(
 
     var showAttachMenu by remember { mutableStateOf(false) }
 
+
+    // 读取内容设置：是否允许发送空文本消息设置
+    val isSendTextAllowEmptySetting by rememberBooleanPreference("send_text_settings", "send_text_allow_empty", false)//英语不好不知道起什么变量名
+
+
 fun insertMentionPlaceholder(text: String, userName: String): String {
     val lastAtIndex = text.lastIndexOf('@')
     if (lastAtIndex == -1) {
@@ -713,14 +718,14 @@ fun insertMentionPlaceholder(text: String, userName: String): String {
                         .pointerInput(currentLongPressSendMarkdownEnabled, currentLongPressSendMarkdownSeconds) {
                             detectTapGestures(
                                 onTap = {
-                                    if (currentText.isNotEmpty()) {
+                                    if (currentText.isNotEmpty()||isSendTextAllowEmptySetting) {
                                         Log.d("ChatInputBar", "Send button tapped")
                                         currentOnSendMessage()
                                     }
                                 },
                                 onLongPress = {
                                     val mtc = currentMtc
-                                    if (currentText.isNotEmpty() && currentLongPressSendMarkdownEnabled && mtc != null) {
+                                    if ((currentText.isNotEmpty()||isSendTextAllowEmptySetting) && currentLongPressSendMarkdownEnabled && mtc != null) {
                                         Log.d("ChatInputBar", "Send button long pressed -> Markdown")
                                         val previousType = currentSelectedMessageType
                                         coroutineScope.launch {
@@ -732,7 +737,7 @@ fun insertMentionPlaceholder(text: String, userName: String): String {
                                                 mtc.invoke(previousType)
                                             }
                                         }
-                                    } else if (currentText.isNotEmpty()) {
+                                    } else if (currentText.isNotEmpty()||isSendTextAllowEmptySetting) {
                                         // 如果没开启长按发送 Markdown，则长按也作为普通发送
                                         Log.d("ChatInputBar", "Send button long pressed (normal send)")
                                         currentOnSendMessage()

--- a/app/src/main/java/com/yhchat/canary/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/yhchat/canary/ui/settings/SettingsScreen.kt
@@ -2090,6 +2090,9 @@ private fun ContentSettingsGroup(context: Context) {
     // 读取图片上传设置
     val imagePrefs = remember { context.getSharedPreferences("image_settings", Context.MODE_PRIVATE) }
     var uploadOriginalImage by remember { mutableStateOf(imagePrefs.getBoolean("upload_original_image", false)) }
+    // 是否允许发送空文本消息设置 //TODO 英语不好不知道起什么变量名
+    val sendTextPrefs = remember { context.getSharedPreferences("send_text_settings", Context.MODE_PRIVATE) }
+    var is_send_text_allow_empty by remember { mutableStateOf(sendTextPrefs.getBoolean("send_text_allow_empty", false)) }
     
     SettingsGroup(
         title = "内容",
@@ -2125,7 +2128,19 @@ private fun ContentSettingsGroup(context: Context) {
                         SavedAudiosActivity.start(context)
                     }
                 )
-            }
+            },
+            {//不知道这个开关放这个位置合不合适
+                SettingsSwitchItem(
+                    icon = Icons.Default.Send,
+                    title = "允许发送空文本消息",
+                    subtitle = "允许发送空文本消息",
+                    checked = is_send_text_allow_empty,
+                    onCheckedChange = { checked ->
+                        is_send_text_allow_empty = checked
+                        sendTextPrefs.edit().putBoolean("send_text_allow_empty", checked).apply()
+                    }
+                )
+            },
         )
     )
 }


### PR DESCRIPTION
比如有时会引用一个之前的消息来表示重复的时候，就不用输入内容
或者单纯的想发空消息来冒泡(?)(不过可能会导致误触)

怕避免出现问题，已添加设置开关。~不过有必要添加设置开关吗，嗯也许有必要吧，防止误触发送~

~我英语不好不知道起什么变量名，并且我写代码的能力也不是很好，所以可能需要您重新检查一下我写的代码是否有问题~